### PR TITLE
Start AA version exchange with USB early to avoid headunit timeouts

### DIFF
--- a/aa_wireless_dongle/package/aawg/src/proxyHandler.cpp
+++ b/aa_wireless_dongle/package/aawg/src/proxyHandler.cpp
@@ -13,6 +13,9 @@
 #include "common.h"
 #include "proxyHandler.h"
 
+constexpr uint16_t default_version_major = 1;
+constexpr uint16_t default_version_minor = 7;
+
 ssize_t AAWProxy::readFully(int fd, unsigned char *buffer, size_t nbyte) {
     size_t remaining_bytes = nbyte;
     while (remaining_bytes > 0) {
@@ -108,7 +111,148 @@ void AAWProxy::forward(ProxyDirection direction, std::atomic<bool>& should_exit)
     should_exit = true;
 }
 
+bool AAWProxy::openUsbAccessory() {
+    Logger::instance()->info("Opening usb accessory\n");
+
+    if ((m_usb_fd = open("/dev/usb_accessory", O_RDWR)) < 0) {
+        Logger::instance()->info("error opening /dev/usb_accessory: %s\n", strerror(errno));
+        return false;
+    }
+
+    return true;
+}
+
+bool AAWProxy::shouldDoEarlyVersionExchange() {
+    // Return false to disable early version exchange
+    return true;
+}
+
+bool AAWProxy::performUsbVersionExchange() {
+    Logger::instance()->info("Attempting early version exchange with USB\n");
+
+    // Receive version request
+    size_t buffer_len = 16;
+    unsigned char buffer[buffer_len];
+
+    ssize_t len = read(m_usb_fd, buffer, buffer_len);
+    Logger::instance()->info("%d bytes read from USB\n", len);
+    if (len < 0) {
+        Logger::instance()->info("Read from USB failed: %s\n", strerror(errno));
+        return false;
+    }
+    else if (len != 10) {
+        Logger::instance()->info("Version exchange with USB failed: expected 10 bytes\n");
+        return false;
+    }
+
+    if (!(buffer[0] == 0 && buffer[1] == 3) // First two bytes of header are 0 and 3 (FRAME_TYPE_FIRST | FRAME_TYPE_LAST)
+        || !(buffer[2] == 0 && buffer[3] == 6) // Length is 6
+        || !(buffer[4] == 0 && buffer[5] == 1) // Control message id is 1 (VERSION_REQUEST)
+    ) {
+        Logger::instance()->info("Version exchange with USB failed: malformed message\n");
+        return false;
+    }
+
+    usb_version_major = (buffer[6] << 8) + buffer[7];
+    usb_version_minor = (buffer[8] << 8) + buffer[9];
+    Logger::instance()->info("USB reported version: major %d, minor %d\n", usb_version_major, usb_version_minor);
+
+    // Send version response
+    unsigned char version_response_buffer[12] = {
+        0x00, 0x03, // Header - FRAME_TYPE_FIRST | FRAME_TYPE_LAST
+        0x00, 0x08, // Payload length
+        0x00, 0x02, // Control message id 2 (VERSION_RESPONSE)
+        (unsigned char)((default_version_major & 0xff00) >> 8), (unsigned char)(default_version_major & 0xff),    // Major version
+        (unsigned char)((default_version_minor & 0xff00) >> 8), (unsigned char)(default_version_minor & 0xff),    // Minor version
+        0x00, 0x00  // Version response status (0 = Match, 0xFFFF = Mismatch)
+    };
+    ssize_t wlen = write(m_usb_fd, version_response_buffer, sizeof(version_response_buffer));
+    Logger::instance()->info("%d bytes written to USB\n", wlen);
+    if (wlen < 0) {
+        Logger::instance()->info("Write to USB failed: %s\n", strerror(errno));
+        return false;
+    }
+
+    Logger::instance()->info("Version exchange completed with USB\n");
+    return true;
+}
+
+bool AAWProxy::performTcpVersionExchange() {
+    // Send version request
+    unsigned char version_request_buffer[10] = {
+        0x00, 0x03, // Header - FRAME_TYPE_FIRST | FRAME_TYPE_LAST
+        0x00, 0x06, // Payload length
+        0x00, 0x01, // Control message id 1 (VERSION_REQUEST)
+        (unsigned char)((usb_version_major & 0xff00) >> 8), (unsigned char)(usb_version_major & 0xff),    // Major version
+        (unsigned char)((usb_version_minor & 0xff00) >> 8), (unsigned char)(usb_version_minor & 0xff),    // Minor version
+    };
+    ssize_t wlen = write(m_tcp_fd, version_request_buffer, sizeof(version_request_buffer));
+    Logger::instance()->info("%d bytes written to TCP\n", wlen);
+    if (wlen < 0) {
+        Logger::instance()->info("Write to TCP failed: %s\n", strerror(errno));
+        return false;
+    }
+
+    // Receive version response
+    size_t buffer_len = 16;
+    unsigned char buffer[buffer_len];
+
+    ssize_t len = read(m_tcp_fd, buffer, buffer_len);
+    Logger::instance()->info("%d bytes read from TCP\n", len);
+    if (len < 0) {
+        Logger::instance()->info("Read from TCP failed: %s\n", strerror(errno));
+        return false;
+    }
+    else if (len != 12) {
+        Logger::instance()->info("Version exchange with TCP failed: expected 12 bytes\n");
+        return false;
+    }
+
+    if (!(buffer[0] == 0 && buffer[1] == 3) // First two bytes of header are 0 and 3 (FRAME_TYPE_FIRST | FRAME_TYPE_LAST)
+        || !(buffer[2] == 0 && buffer[3] == 8) // Length is 8
+        || !(buffer[4] == 0 && buffer[5] == 2) // Control message id is 2 (VERSION_RESPONSE)
+    ) {
+        Logger::instance()->info("Version exchange with TCP failed: malformed message\n");
+        return false;
+    }
+
+    uint16_t tcp_version_major = (buffer[6] << 8) + buffer[7];
+    uint16_t tcp_version_minor = (buffer[8] << 8) + buffer[9];
+    Logger::instance()->info("TCP reported version: major %d, minor %d\n", tcp_version_major, tcp_version_minor);
+
+    if (tcp_version_major != default_version_major || tcp_version_minor != default_version_minor) {
+        Logger::instance()->info("Version from TCP does not match version earlier reported (major %d, minor %d) to USB!\n", default_version_major, default_version_minor);
+    }
+
+    uint16_t tcp_version_response_status = (buffer[10] << 8) + buffer[11];
+    switch (tcp_version_response_status) {
+        case 0: // Match
+            break;
+        case 0xFF:  // Mismatch
+            Logger::instance()->info("TCP reported version mismatch\n");
+            break;
+        default:
+            Logger::instance()->info("TCP reported unknown version response status\n");
+            break;
+    }
+
+    Logger::instance()->info("Version exchange completed with TCP\n");
+    return true;
+}
+
 void AAWProxy::handleClient(int server_sock) {
+    bool earlyVersionExchange = shouldDoEarlyVersionExchange();
+    if (earlyVersionExchange) {
+        if (!openUsbAccessory()) {
+            return;
+        }
+
+        if (!performUsbVersionExchange()) {
+            // Better error handling? Maybe store the buffer received from usb and use as is when forwarding starts?
+            return;
+        }
+    }
+
     struct sockaddr client_address;
     socklen_t client_addresslen = sizeof(client_address);
     if ((m_tcp_fd = accept(server_sock, &client_address, &client_addresslen)) < 0) {
@@ -121,10 +265,14 @@ void AAWProxy::handleClient(int server_sock) {
 
     Logger::instance()->info("Tcp server accepted connection\n");
 
-    Logger::instance()->info("Opening usb accessory\n");
-    if ((m_usb_fd = open("/dev/usb_accessory", O_RDWR)) < 0) {
-        Logger::instance()->info("error opening /dev/usb_accessory: %s\n", strerror(errno));
-        return;
+    if (earlyVersionExchange) {
+        if (!performTcpVersionExchange()) {
+            return;
+        }
+    } else {
+        if (!openUsbAccessory()) {
+            return;
+        }
     }
 
     Logger::instance()->info("Frowarding data between TCP and USB\n");

--- a/aa_wireless_dongle/package/aawg/src/proxyHandler.cpp
+++ b/aa_wireless_dongle/package/aawg/src/proxyHandler.cpp
@@ -155,7 +155,7 @@ bool AAWProxy::performUsbVersionExchange() {
 
     usb_version_major = (buffer[6] << 8) + buffer[7];
     usb_version_minor = (buffer[8] << 8) + buffer[9];
-    Logger::instance()->info("USB reported version: major %d, minor %d\n", usb_version_major, usb_version_minor);
+    Logger::instance()->info("USB reported version: %d.%d\n", usb_version_major, usb_version_minor);
 
     // Send version response
     unsigned char version_response_buffer[12] = {
@@ -218,10 +218,10 @@ bool AAWProxy::performTcpVersionExchange() {
 
     uint16_t tcp_version_major = (buffer[6] << 8) + buffer[7];
     uint16_t tcp_version_minor = (buffer[8] << 8) + buffer[9];
-    Logger::instance()->info("TCP reported version: major %d, minor %d\n", tcp_version_major, tcp_version_minor);
+    Logger::instance()->info("TCP reported version: %d.%d\n", tcp_version_major, tcp_version_minor);
 
     if (tcp_version_major != default_version_major || tcp_version_minor != default_version_minor) {
-        Logger::instance()->info("Version from TCP does not match version earlier reported (major %d, minor %d) to USB!\n", default_version_major, default_version_minor);
+        Logger::instance()->info("Version from TCP does not match version earlier reported (%d.%d) to USB!\n", default_version_major, default_version_minor);
     }
 
     uint16_t tcp_version_response_status = (buffer[10] << 8) + buffer[11];

--- a/aa_wireless_dongle/package/aawg/src/proxyHandler.h
+++ b/aa_wireless_dongle/package/aawg/src/proxyHandler.h
@@ -20,6 +20,15 @@ private:
     ssize_t readFully(int fd, unsigned char *buf, size_t nbyte);
     ssize_t readMessage(int fd, unsigned char *buf, size_t nbyte);
 
+    bool openUsbAccessory();
+
+    bool shouldDoEarlyVersionExchange();
+    bool performUsbVersionExchange();
+    bool performTcpVersionExchange();
+
     int m_usb_fd = -1;
     int m_tcp_fd = -1;
+
+    uint16_t usb_version_major = 0;
+    uint16_t usb_version_minor = 0;
 };


### PR DESCRIPTION
Many head units seems to have some timeout for the AA communication to start. Try to work around the timeout by doing the version handshake early with the head unit while we wait for the phone to connect via TCP.