### PR TITLE
Connect to usb after phone connection is available

### DIFF
--- a/aa_wireless_dongle/package/aawg/src/aawgd.cpp
+++ b/aa_wireless_dongle/package/aawg/src/aawgd.cpp
@@ -17,8 +17,6 @@ int main(void) {
 
     while (true) {
         // Per connection setup and processing
-        UsbManager::instance().enableDefaultAndWaitForAccessroy();
-
         AAWProxy proxy;
         std::optional<std::thread> proxyThread = proxy.startServer(Config::instance()->getWifiInfo().port);
 

--- a/aa_wireless_dongle/package/aawg/src/proxyHandler.cpp
+++ b/aa_wireless_dongle/package/aawg/src/proxyHandler.cpp
@@ -11,6 +11,7 @@
 #include <string>
 
 #include "common.h"
+#include "usb.h"
 #include "proxyHandler.h"
 
 ssize_t AAWProxy::readFully(int fd, unsigned char *buffer, size_t nbyte) {
@@ -120,6 +121,8 @@ void AAWProxy::handleClient(int server_sock) {
     close(server_sock);
 
     Logger::instance()->info("Tcp server accepted connection\n");
+
+    UsbManager::instance().enableDefaultAndWaitForAccessroy();
 
     Logger::instance()->info("Opening usb accessory\n");
     if ((m_usb_fd = open("/dev/usb_accessory", O_RDWR)) < 0) {


### PR DESCRIPTION
Seems like many head units have small timeouts that do not allow the entire Wireless AA connection process with phone.

Currently we wait first for the head unit to send the accessory start request to make sure it wants to use AA. Once that happens, we start the BT connection with the phone to start Wireless AA.

Instead of this, first try to connect to phone anyway. Once we have the phone ready with TCP connection, start the default gadget and wait for the accessory start request from head unit.